### PR TITLE
ProgressBar IE input range onChange fix

### DIFF
--- a/src/components/progressbar/ProgressBar.js
+++ b/src/components/progressbar/ProgressBar.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import throttle from 'lodash.throttle';
 
 var ProgressBar = React.createClass({
 
@@ -27,10 +28,22 @@ var ProgressBar = React.createClass({
         // is required for Firefox. Setting manually.
         // https://github.com/facebook/react/issues/2453
         this.refs.input.setAttribute('orient', this.props.orientation);
+
+        // There is a known issue with the range input onChange event in IE
+        // https://github.com/facebook/react/issues/3096
+        //
+        // Until that is resolved, the workaround here is to also use the
+        // onClick event in addition to onChange.
+        //
+        // And here we throttle our event handler so we don't double
+        // post events in browsers that support both onChange and onClick.
+        this.throttledOnChange = throttle(this.onChange, 200);
     },
 
-    onChange() {
-        // Placeholder
+    onChange(e) {
+        if (e.target) {
+            this.props.onChange(e);
+        }
     },
 
     onFocus() {
@@ -52,7 +65,8 @@ var ProgressBar = React.createClass({
                     onBlur={this.props.onBlur}
                     onFocus={this.props.onFocus}
                     ref="input"
-                    onChange={this.props.onChange}
+                    onChange={this.throttledOnChange}
+                    onClick={this.throttledOnChange}
                     type="range"
                     min="0"
                     max="100"


### PR DESCRIPTION
Hi @mderrick, Here's a workaround fix for #9.

The seek behavior in IE 11 is still a little buggy, but at least it _works_. Having seeking working (even if only somewhat) in IE is pretty important to us - so I thought I'd still submit this workaround anyways even though I don't love it. And of course, I'd be open to suggestions/feedback.

I've tested this using the following browsers:

- Chrome 48.0.2564.97
  - seek
      - mouse: ok
      - keyboard: ok
  - volume
     - mouse: ok
     - keyboard: no, but I'm not sure if this worked before though
- Safari 9.0.3 (11601.4.4)
  - seek
      - mouse: ok
      - keyboard: ok
  - volume
     - mouse: ok
     - keyboard: no, but I'm not sure if this worked before though
- Firefox 44.0
  - seek
      - mouse: ok
      - keyboard: ok
  - volume
     - mouse: ok
     - keyboard: no, but I'm not sure if this worked before though
- IE Edge 20.10240.16384.0
  - seek
      - mouse: ok
      - keyboard: ok
  - volume
     - mouse: **NO**
     - keyboard: no, but I'm not sure if this worked before though
- IE 11.0.10240.16644
  - seek
      - mouse: ok, **but a little buggy**
      - keyboard: **NO**
  - volume
     - mouse: **NO**
     - keyboard: no, but I'm not sure if this worked before though

Other notes:

- The volume bar still isn't working in IE 11 (on either mouse or keyboard), but I _think_ that could be a different issue - I can investigate some more and create separate PR if I'm able to track that one down.
- In evaluating fixes for this, I also tried [react-range](https://github.com/mapbox/react-range), but with that, the behavior of the seek bar was pretty buggy in all the browsers, so I went in the direction of this more specific fix here in this PR.