### PR TITLE
optimize fullscreen implement

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ All children components receive the following methods via props:
 - `unmute`
 - `toggleMute`
 - `seek`
-- `fullscreen`
+- `toggleFullscreen`
 - `setVolume`
 
 ## Contributing

--- a/demo/src/components/index/main/main.css
+++ b/demo/src/components/index/main/main.css
@@ -26,7 +26,7 @@
 
 .main__video {
     position: relative;
-    display: block;
+    display: flex;
     width: 634px;
     height: 356px;
     margin: 0 auto;

--- a/src/components/controls/Controls.js
+++ b/src/components/controls/Controls.js
@@ -27,6 +27,15 @@ var Controls = React.createClass({
         };
     },
 
+    getControlsClassName() {
+        let base = "video-controls video__controls";
+        if (this.props.isFullscreen()) {
+            return base;
+        } else {
+            return base + " video__fullhover";
+        }
+    },
+
     /**
      * Returns children components with props
      * from the parent Video component. Needed
@@ -42,7 +51,7 @@ var Controls = React.createClass({
     render() {
         return (
             !this.props.error ? (
-                <div className="video-controls video__controls">
+                <div className={this.getControlsClassName()}>
                     {this.renderChildren()}
                 </div>
             ) : null

--- a/src/components/controls/fullscreen/Fullscreen.js
+++ b/src/components/controls/fullscreen/Fullscreen.js
@@ -5,7 +5,7 @@ var Fullscreen = React.createClass({
 
     propTypes: {
         copyKeys: React.PropTypes.object,
-        fullscreen: React.PropTypes.func
+        toggleFullscreen: React.PropTypes.func
     },
 
     /**
@@ -15,13 +15,13 @@ var Fullscreen = React.createClass({
      * @return {boolean}          Whether we re-render or not
      */
     shouldComponentUpdate(nextProps) {
-        return this.props.fullscreen !== nextProps.fullscreen;
+        return this.props.toggleFullscreen !== nextProps.toggleFullscreen;
     },
 
     render() {
         return (
             <button
-                onClick={this.props.fullscreen}
+                onClick={this.props.toggleFullscreen}
                 className="video-fullscreen video__control"
                 aria-label={this.props.copyKeys.fullscreen}>
                 <Icon name="resize-full" />

--- a/src/components/video/Video.js
+++ b/src/components/video/Video.js
@@ -154,8 +154,7 @@ var Video = React.createClass({
      */
     toggleFullscreen() {
         const ce = this.containerEl;
-        if (!document.fullscreenElement &&    // alternative standard method
-            !document.mozFullScreenElement && !document.webkitFullscreenElement && !document.msFullscreenElement ) {  // current working methods
+        if (!this.isFullscreen()) {
             if (ce.requestFullscreen) {
                 ce.requestFullscreen();
             } else if (ce.msRequestFullscreen) {
@@ -165,6 +164,7 @@ var Video = React.createClass({
             } else if (ce.webkitRequestFullscreen) {
                 ce.webkitRequestFullscreen(Element.ALLOW_KEYBOARD_INPUT);
             }
+            this.onBlur();
         } else {
             if (document.exitFullscreen) {
                 document.exitFullscreen();
@@ -176,6 +176,16 @@ var Video = React.createClass({
                 document.webkitExitFullscreen();
             }
         }
+    },
+
+    /**
+     * Is full screen?
+     */
+    isFullscreen() {
+        return document.fullscreenElement ||
+            document.mozFullScreenElement ||
+            document.webkitFullscreenElement ||
+            document.msFullscreenElement;
     },
 
     /**
@@ -270,6 +280,7 @@ var Video = React.createClass({
             unmute: this.unmute,
             seek: this.seek,
             toggleFullscreen: this.toggleFullscreen,
+            isFullscreen: this.isFullscreen,
             setVolume: this.setVolume
         }, this.state, {copyKeys: this.props.copyKeys});
 
@@ -332,9 +343,11 @@ var Video = React.createClass({
      * @return {undefined}
      */
     onFocus() {
-        this.setState({
-            focused: true
-        });
+        if (!this.isFullscreen()) {
+            this.setState({
+                focused: true
+            });
+        }
     },
 
     /**

--- a/src/components/video/Video.js
+++ b/src/components/video/Video.js
@@ -149,18 +149,32 @@ var Video = React.createClass({
     },
 
     /**
-     * Sets the video to fullscreen.
+     * toggle the video to fullscreen and window.
      * @return {undefined}
      */
-    fullscreen() {
-        if (this.videoEl.requestFullscreen) {
-            this.videoEl.requestFullscreen();
-        } else if (this.videoEl.msRequestFullscreen) {
-            this.videoEl.msRequestFullscreen();
-        } else if (this.videoEl.mozRequestFullScreen) {
-            this.videoEl.mozRequestFullScreen();
-        } else if (this.videoEl.webkitRequestFullscreen) {
-            this.videoEl.webkitRequestFullscreen();
+    toggleFullscreen() {
+        const ce = this.containerEl;
+        if (!document.fullscreenElement &&    // alternative standard method
+            !document.mozFullScreenElement && !document.webkitFullscreenElement && !document.msFullscreenElement ) {  // current working methods
+            if (ce.requestFullscreen) {
+                ce.requestFullscreen();
+            } else if (ce.msRequestFullscreen) {
+                ce.msRequestFullscreen();
+            } else if (ce.mozRequestFullScreen) {
+                ce.mozRequestFullScreen();
+            } else if (ce.webkitRequestFullscreen) {
+                ce.webkitRequestFullscreen(Element.ALLOW_KEYBOARD_INPUT);
+            }
+        } else {
+            if (document.exitFullscreen) {
+                document.exitFullscreen();
+            } else if (document.msExitFullscreen) {
+                document.msExitFullscreen();
+            } else if (document.mozCancelFullScreen) {
+                document.mozCancelFullScreen();
+            } else if (document.webkitExitFullscreen) {
+                document.webkitExitFullscreen();
+            }
         }
     },
 
@@ -255,7 +269,7 @@ var Video = React.createClass({
             mute: this.mute,
             unmute: this.unmute,
             seek: this.seek,
-            fullscreen: this.fullscreen,
+            toggleFullscreen: this.toggleFullscreen,
             setVolume: this.setVolume
         }, this.state, {copyKeys: this.props.copyKeys});
 
@@ -342,7 +356,10 @@ var Video = React.createClass({
             <div className={this.getVideoClassName()}
                 tabIndex="0"
                 onFocus={this.onFocus}
-                onBlur={this.onBlur}>
+                onBlur={this.onBlur}
+                ref={ref => {
+                    this.containerEl = ref;
+                }}>
                 <video
                     {...otherProps}
                     className="video__el"

--- a/src/components/video/video.css
+++ b/src/components/video/video.css
@@ -25,6 +25,7 @@
 }
 
 .video--focused .video__controls,
-.video:hover .video__controls {
+.video:hover .video__controls:hover,
+.video:hover .video__fullhover {
     opacity: 1;
 }


### PR DESCRIPTION
I found `fullscreen()` method simply call method of video element. That will hide CustomComponents.
So I made fullscreen method to call **requestFullscreen of parent `div`.
And I change `fullscreen `method to `toggleFullscreen`. (reference: https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API)

When run demo, I found the width of `div`(call fullscreen) is limited by the width of video in chrome(IE11 is OK). But I change the style of it's parent `div` from `display: block;` to `display: flex;`, it works well.