### PR TITLE
Custom class for focused video 

### DIFF
--- a/src/components/video/Video.js
+++ b/src/components/video/Video.js
@@ -51,7 +51,8 @@ var Video = React.createClass({
 
     getDefaultProps() {
         return {
-            copyKeys: copy
+            copyKeys: copy,
+            focusedClassName: 'video--focused'
         };
     },
 
@@ -306,7 +307,7 @@ var Video = React.createClass({
         }
 
         if (this.state.focused) {
-            classString += ' video--focused';
+            classString += ` ${this.props.focusedClassName}`;
         }
         if (className) {
             classString += ' ' + className;


### PR DESCRIPTION
The `video--focused` class will stay the default. But optionally the user can set a focusedClassName so he can apply custom styling if the video is focused.

#39 