### PR TITLE
Remove seek and volume actions from throttling to improve smoothness …

### DIFF
--- a/dist/ReactHtml5Video.js
+++ b/dist/ReactHtml5Video.js
@@ -308,6 +308,10 @@ return /******/ (function(modules) { // webpackBootstrap
 	     */
 	    seek: function seek(time) {
 	        this.videoEl.currentTime = time;
+	        this.setState({
+	            currentTime: time,
+	            percentagePlayed: time / this.videoEl.duration * 100
+	        });
 	    },
 
 	    /**
@@ -317,6 +321,9 @@ return /******/ (function(modules) { // webpackBootstrap
 	     */
 	    setVolume: function setVolume(volume) {
 	        this.videoEl.volume = volume;
+	        this.setState({
+	            volume: volume
+	        });
 	    },
 
 	    /**
@@ -332,7 +339,6 @@ return /******/ (function(modules) { // webpackBootstrap
 	            buffered: this.videoEl.buffered,
 	            paused: this.videoEl.paused,
 	            muted: this.videoEl.muted,
-	            volume: this.videoEl.volume,
 	            readyState: this.videoEl.readyState,
 
 	            // Non-standard state computed from properties
@@ -645,7 +651,7 @@ return /******/ (function(modules) { // webpackBootstrap
 /* 29 */
 /***/ function(module, exports) {
 
-	var core = module.exports = {version: '2.2.2'};
+	var core = module.exports = {version: '2.4.0'};
 	if(typeof __e == 'number')__e = core; // eslint-disable-line no-undef
 
 /***/ },

--- a/src/components/video/Video.js
+++ b/src/components/video/Video.js
@@ -200,6 +200,10 @@ var Video = React.createClass({
      */
     seek(time) {
         this.videoEl.currentTime = time;
+        this.setState({
+            currentTime: time,
+            percentagePlayed: time / this.videoEl.duration * 100
+        });
     },
 
     /**
@@ -209,6 +213,9 @@ var Video = React.createClass({
      */
     setVolume(volume) {
         this.videoEl.volume = volume;
+        this.setState({
+            volume: volume
+        });
     },
 
     /**
@@ -224,7 +231,6 @@ var Video = React.createClass({
             buffered: this.videoEl.buffered,
             paused: this.videoEl.paused,
             muted: this.videoEl.muted,
-            volume: this.videoEl.volume,
             readyState: this.videoEl.readyState,
 
             // Non-standard state computed from properties


### PR DESCRIPTION
…of progressbar. So both bars seem completely smooth on my laptop and it doesn't seem to have any side effect.

I just call the setState directly in the callback. I kept the throttling method for everything else.
I think we shouldn't worry too much about the number of renders generated as React is suppose to deal with that anyway.
Maybe a quick test on a slow/mobile device would let us know if it's fine this way or not.
Thanks!
