### PR TITLE
Fix #43 where seek bar and volume control feel janky

### DIFF
--- a/src/components/controls/mute/Mute.js
+++ b/src/components/controls/mute/Mute.js
@@ -33,7 +33,7 @@ var Mute = React.createClass({
      * @return {undefined}
      */
     changeVolume(e) {
-        this.props.setVolume(e.target.value / 100);
+        this.props.setVolume(e.target.value / 100, true);
         this.props.unmute();
     },
 

--- a/src/components/controls/seek/Seek.js
+++ b/src/components/controls/seek/Seek.js
@@ -40,7 +40,7 @@ var Seek = React.createClass({
      * @return {undefined}
      */
     seek(e) {
-        this.props.seek(e.target.value * this.props.duration / 100);
+        this.props.seek(e.target.value * this.props.duration / 100, true);
     },
 
     onFocus() {

--- a/src/components/video/Video.js
+++ b/src/components/video/Video.js
@@ -196,19 +196,37 @@ var Video = React.createClass({
     /**
      * Seeks the video timeline.
      * @param  {number} time The value in seconds to seek to
+     * @param  {bool}   forceUpdate Forces a state update without waiting for
+     *                              throttled event.          
      * @return {undefined}
      */
-    seek(time) {
+    seek(time, forceUpdate) {
         this.videoEl.currentTime = time;
+        // In some use cases, we wish not to wait for `onSeeked` or `onSeeking`
+        // throttled event to update state so we force it. This is because
+        // this method is often triggered when dragging a bar and can feel janky.
+        // See https://github.com/mderrick/react-html5video/issues/43
+        if (forceUpdate) {
+            this.updateStateFromVideo();
+        }
     },
 
     /**
      * Sets the video volume.
      * @param  {number} volume The volume level between 0 and 1.
+     * @param  {bool}   forceUpdate Forces a state update without waiting for
+     *                              throttled event.  
      * @return {undefined}
      */
-    setVolume(volume) {
+    setVolume(volume, forceUpdate) {
         this.videoEl.volume = volume;
+        // In some use cases, we wish not to wait for `onVolumeChange`
+        // throttled event to update state so we force it. This is because
+        // this method is often triggered when dragging a bar and can feel janky.
+        // See https://github.com/mderrick/react-html5video/issues/43
+        if (forceUpdate) {
+            this.updateStateFromVideo();
+        }
     },
 
     /**


### PR DESCRIPTION
Based primarily on @Grsmto's solution (thank you!) which can be found in PR https://github.com/mderrick/react-html5video/pull/44 but with a few changes.

1. Opt in to using the force update in case the `seek` and `setVolume` method are used outside of a drag implementation where it's OK that they do not update instantly.

2. Instead of duplicating some logic, simply recalculate all state by calling `updateStateFromVideo` directly.