### PR TITLE
Add style prop support

### DIFF
--- a/src/components/video/Video.js
+++ b/src/components/video/Video.js
@@ -360,12 +360,13 @@ var Video = React.createClass({
         // and use our own controls.
         // Leave `copyKeys` here even though not used
         // as per issue #36.
-        var {controls, copyKeys, ...otherProps} = this.props;
+        var {controls, copyKeys, style, ...otherProps} = this.props;
         return (
             <div className={this.getVideoClassName()}
                 tabIndex="0"
                 onFocus={this.onFocus}
-                onBlur={this.onBlur}>
+                onBlur={this.onBlur}
+                style={style}>
                 <video
                     {...otherProps}
                     className="video__el"


### PR DESCRIPTION
Add style prop support to the container `div`, allowing users of JavaScript based styles to target the container `div` in the same manor as when using the `className` prop