### PR TITLE
Prevents recreation of ref function on every render

### DIFF
--- a/src/components/video/Video.js
+++ b/src/components/video/Video.js
@@ -200,7 +200,7 @@ var Video = React.createClass({
      * Seeks the video timeline.
      * @param  {number} time The value in seconds to seek to
      * @param  {bool}   forceUpdate Forces a state update without waiting for
-     *                              throttled event.          
+     *                              throttled event.
      * @return {undefined}
      */
     seek(time, forceUpdate) {
@@ -218,7 +218,7 @@ var Video = React.createClass({
      * Sets the video volume.
      * @param  {number} volume The volume level between 0 and 1.
      * @param  {bool}   forceUpdate Forces a state update without waiting for
-     *                              throttled event.  
+     *                              throttled event.
      * @return {undefined}
      */
     setVolume(volume, forceUpdate) {
@@ -368,6 +368,15 @@ var Video = React.createClass({
         });
     },
 
+    /**
+     * Sets a ref to the video element.
+     * @param  {node} el The video element reference
+     * @return {undefined}
+     */
+    setVideoRef(el) {
+        this.videoEl = el;
+    },
+
     render() {
         // If controls prop is provided remove it
         // and use our own controls.
@@ -383,9 +392,7 @@ var Video = React.createClass({
                 <video
                     {...otherProps}
                     className="video__el"
-                    ref={(el) => {
-                        this.videoEl = el;
-                    }}
+                    ref={this.setVideoRef}
                     //  We have throttled `_updateStateFromVideo` so listen to
                     //  every available Media event that React allows and
                     //  infer the Video state in that method from the Video properties.


### PR DESCRIPTION
### Issue
We are using the `Video` component within a larger component that includes some elements that need regular updating. As a result, we noticed that the ref to the `<video>` element would be assigned to `null` and then to the DOM node for each re-render. This caused some transitory issues when attempting to access the ref in things like event handlers.

### Fix
By defining the ref function within the JSX, that function is being recreated on each render. As a result, the "old" function receives a `null` node ref, and the "new" function receives the actual node ref on each render (https://github.com/facebook/react/issues/4533#issuecomment-126807678). We've moved that function onto the component itself so that it is only created once.

P.S. My editor automatically removes trailing spaces - let me know if this is a problem and I can remove those changes.