### PR TITLE
Bring in react-test-render in favour of react-addons-test-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,17 +89,17 @@
     "lodash.throttle": "^4.1.1",
     "open": "0.0.5",
     "postcss-loader": "^1.1.1",
+    "prop-types": "^15.5.10",
     "react": "^15.4.0",
-    "react-addons-test-utils": "^15.4.0",
     "react-dom": "^15.4.0",
     "react-hot-loader": "^3.0.0-beta.6",
     "react-svg-loader": "^1.1.1",
+    "react-test-renderer": "^15.5.4",
     "recompose": "^0.20.2",
     "style-loader": "^0.13.1",
     "url-loader": "^0.5.7",
     "webpack": "^1.13.3",
     "webpack-dev-middleware": "^1.8.4",
-    "webpack-hot-middleware": "^2.13.2",
-     "prop-types": "^15.5.10"
+    "webpack-hot-middleware": "^2.13.2"
   }
 }


### PR DESCRIPTION
Allows enzyme to use it, to resolve the warnings during the tests.

Also formats the `package.json` correctly.