### PR TITLE
Remove lodash.throttle from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^18.0.0",
     "json-loader": "^0.5.4",
-    "lodash.throttle": "^4.1.1",
     "open": "0.0.5",
     "postcss-loader": "^1.1.1",
     "prop-types": "^15.5.10",


### PR DESCRIPTION
This appears to be unused since e0ddd39c06dd.