### PR TITLE
Show minutes and seconds only if video length less than 1 hour

### DIFF
--- a/src/DefaultPlayer/Time/Time.js
+++ b/src/DefaultPlayer/Time/Time.js
@@ -7,13 +7,8 @@ const formatTime = (seconds) => {
         ? 0
         : Math.floor(seconds);
     date.setSeconds(seconds);
-    let timeStamp = date.toISOString();
-    if (seconds >= 3600) {
-        timeStamp = timeStamp.substr(11, 8);
-    } else {
-        timeStamp = timeStamp.substr(14, 5);
-    }
-    return timeStamp;
+    const duration = date.toISOString().substr(11, 8).replace(/^0{1,2}:?0{0,1}/,'');
+    return duration;
 };
 
 export default ({ currentTime, duration, className }) => {

--- a/src/DefaultPlayer/Time/Time.js
+++ b/src/DefaultPlayer/Time/Time.js
@@ -7,7 +7,13 @@ const formatTime = (seconds) => {
         ? 0
         : Math.floor(seconds);
     date.setSeconds(seconds);
-    return date.toISOString().substr(11, 8);
+    let timeStamp = date.toISOString();
+    if (seconds >= 3600) {
+        timeStamp = timeStamp.substr(11, 8);
+    } else {
+        timeStamp = timeStamp.substr(14, 5);
+    }
+    return timeStamp;
 };
 
 export default ({ currentTime, duration, className }) => {

--- a/src/DefaultPlayer/Time/Time.test.js
+++ b/src/DefaultPlayer/Time/Time.test.js
@@ -28,7 +28,7 @@ describe('Time', () => {
             duration: 10
         });
         expect(component.find(`.${styles.duration}`).text())
-            .toEqual('00:00:10');
+            .toEqual('0:10');
     });
 
     it('shows current video elapsed time', () => {
@@ -36,7 +36,7 @@ describe('Time', () => {
             currentTime: 10
         });
         expect(component.find(`.${styles.current}`).text())
-            .toEqual('00:00:10');
+            .toEqual('0:10');
     });
 
     it('can handle minutes, hours and seconds', () => {
@@ -44,19 +44,19 @@ describe('Time', () => {
             currentTime: 60 * 2
         });
         expect(component.find(`.${styles.current}`).text())
-            .toEqual('00:02:00');
+            .toEqual('2:00');
 
         component.setProps({
             currentTime: 60 * 60 * 3
         });
         expect(component.find(`.${styles.current}`).text())
-            .toEqual('03:00:00');
+            .toEqual('3:00:00');
 
         component.setProps({
             currentTime: 60 * 60 * 3 + 72
         });
         expect(component.find(`.${styles.current}`).text())
-            .toEqual('03:01:12');
+            .toEqual('3:01:12');
     });
 
     it('fails gracefully and shows 00:00:00 when video is greater than 24 hours', () => {
@@ -66,26 +66,26 @@ describe('Time', () => {
             currentTime: 86401
         });
         expect(component.find(`.${styles.current}`).text())
-            .toEqual('00:00:00');
+            .toEqual('0:00');
 
         component.setProps({
             currentTime: 86400
         });
         expect(component.find(`.${styles.current}`).text())
-            .toEqual('00:00:00');
+            .toEqual('0:00');
     });
 
-    it('fails gracefully and shows 00:00:00 when not given a number', () => {
+    it('fails gracefully and shows 00:00 when not given a number', () => {
         component.setProps({
             currentTime: null
         });
         expect(component.find(`.${styles.current}`).text())
-            .toEqual('00:00:00');
+            .toEqual('0:00');
 
         component.setProps({
             currentTime: undefined
         });
         expect(component.find(`.${styles.current}`).text())
-            .toEqual('00:00:00');
+            .toEqual('0:00');
     });
 });


### PR DESCRIPTION
I think this should make it looks nicer if the video length less than `3600` seconds = 1 hour

Less than 3600 seconds `6:40`
More or equal 3600 seconds `1:06:00`

Not sure if you gonna like it or not. feel free to close if so.