### PR TITLE
Add display:block to video styles

### DIFF
--- a/src/DefaultPlayer/DefaultPlayer.css
+++ b/src/DefaultPlayer/DefaultPlayer.css
@@ -8,6 +8,7 @@
 .video {
     width: 100%;
     height: 100%;
+    display: block;
 }
 
 .controls {


### PR DESCRIPTION
### Description

Sometimes the height of the video element is not calculated correctly, resulting in black bars under the video, which would be part of the parent container, and thus the controls etc. This is due to the default styling being `display: inline`, which doesn't always calculate height correctly. This PR proposes a simple fix, adding `display: block` to the HTML `<video>` element.

### Screenshots

Before:
![screen shot 2018-09-13 at 14 56 23](https://user-images.githubusercontent.com/8533554/45493169-1021d500-b766-11e8-8746-5e5ecb4d0650.png)

After:
![screen shot 2018-09-13 at 14 56 30](https://user-images.githubusercontent.com/8533554/45493171-1021d500-b766-11e8-82c7-c588c4e02344.png)