### PR TITLE
Fix for #131 (error with Server-side-rendered apps due to use of navigator on server side)

### DIFF
--- a/src/DefaultPlayer/DefaultPlayer.js
+++ b/src/DefaultPlayer/DefaultPlayer.js
@@ -122,6 +122,11 @@ DefaultPlayer.propTypes = {
     video: PropTypes.object.isRequired
 };
 
+
+// Check if we're on the server side.
+// This is because otherwise accessing things like navigator or window may break the app when the app has server side rendering.
+const isServerSide = () => !(typeof window !== 'undefined' && window !== null);
+
 const connectedPlayer = videoConnect(
     DefaultPlayer,
     ({ networkState, readyState, error, ...restState }) => ({
@@ -132,7 +137,7 @@ const connectedPlayer = videoConnect(
             // TODO: This is not pretty. Doing device detection to remove
             // spinner on iOS devices for a quick and dirty win. We should see if
             // we can use the same readyState check safely across all browsers.
-            loading: readyState < (/iPad|iPhone|iPod/.test(navigator.userAgent) ? 1 : 4),
+            loading: readyState < (!isServerSide() && /iPad|iPhone|iPod/.test(navigator.userAgent) ? 1 : 4),
             percentagePlayed: getPercentagePlayed(restState),
             percentageBuffered: getPercentageBuffered(restState),
             ...restState


### PR DESCRIPTION
Added a check if we're on the server side,  to avoid accessing (in the server side) things like navigator or window which may break the app when the app has server side rendering (like next.js, react-static, ...) 

Fixes #131 