### PR TITLE
Make overlay buttons accessible

### DIFF
--- a/src/DefaultPlayer/DefaultPlayer.js
+++ b/src/DefaultPlayer/DefaultPlayer.js
@@ -51,6 +51,7 @@ const DefaultPlayer = ({
             </video>
             <Overlay
                 onClick={onPlayPauseClick}
+                copy={copy.overlay}
                 {...video} />
             { controls && controls.length && !video.error
                 ? <div className={styles.controls}>

--- a/src/DefaultPlayer/Overlay/Overlay.css
+++ b/src/DefaultPlayer/Overlay/Overlay.css
@@ -24,6 +24,10 @@
     margin-left: -30px;
     background-color: rgba(0,0,0,0.7);
     border-radius: 10px;
+    border: none;
+    padding:0;
+    outline: none;
+    cursor: pointer;
 }
 
 .icon {
@@ -33,4 +37,15 @@
     left: 50%;
     margin-left: -20px;
     transform: translateY(-50%);
+}
+
+.srOnly {
+	border: 0;
+	clip: rect(0 0 0 0);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	width: 1px;
 }

--- a/src/DefaultPlayer/Overlay/Overlay.js
+++ b/src/DefaultPlayer/Overlay/Overlay.js
@@ -9,31 +9,36 @@ export default class Overlay extends Component {
         const {
             error,
             paused,
-            loading
+            loading,
+            copy
         } = this.props;
         const iconProps = {
             className: styles.icon,
             height: 40,
             width: 40,
-            fill: '#fff'
+            fill: '#fff',
+            'aria-hidden': true,
         };
         if (error) {
             return (
-                <span className={styles.inner}>
+                <button className={styles.inner}>
+                    <span className={styles.srOnly}>{copy.error}</span>
                     <Report {...iconProps} />
-                </span>
+                </button>
             );
         } else if (loading) {
             return (
-                <span className={styles.inner}>
+                <button className={styles.inner}>
+                    <span className={styles.srOnly}>{copy.loading}</span>
                     <Spin {...iconProps} />
-                </span>
+                </button>
             );
         } else if (paused) {
             return (
-                <span className={styles.inner}>
+                <button className={styles.inner}>
+                    <span className={styles.srOnly}>{copy.paused}</span>
                     <PlayArrow {...iconProps} />
-                </span>
+                </button>
             );
         }
     }
@@ -41,12 +46,11 @@ export default class Overlay extends Component {
     render () {
         const { className, onClick } = this.props;
         return (
-            <div className={[
-                styles.component,
-                className
-            ].join(' ')}
-            onClick={onClick}>
-                { this.renderContent() }
+            <div
+                className={[styles.component, className].join(' ')}
+                onClick={onClick}
+            >
+                {this.renderContent()}
             </div>
         );
     }

--- a/src/DefaultPlayer/copy.js
+++ b/src/DefaultPlayer/copy.js
@@ -6,7 +6,12 @@ const copy = {
     volume: 'Change volume',
     fullscreen: 'View video fullscreen',
     seek: 'Seek video',
-    captions: 'Toggle captions'
+    captions: 'Toggle captions',
+    overlay: {
+        loading: 'Loading Video...',
+        paused: 'Play Video',
+        error: 'Unable to play video'
+    }
 };
 
 export default copy;


### PR DESCRIPTION
Uses an actual `button` element for the buttons
on the overlay and adds screen-reader-only text
for icons inside them. No change in UI.